### PR TITLE
feat: UTA logo in education, remove dead logo fields

### DIFF
--- a/src/features/profile/data/experiences.ts
+++ b/src/features/profile/data/experiences.ts
@@ -143,6 +143,7 @@ export const EXPERIENCES: Experience[] = [
   {
     id: "education",
     companyName: "Education",
+    companyLogo: "/images/experience/uta.png",
     positions: [
       {
         id: "c47f5903-88ae-4512-8a50-0b91b0cf99b6",

--- a/src/features/profile/data/projects.ts
+++ b/src/features/profile/data/projects.ts
@@ -2,28 +2,6 @@ import { Project } from "@/features/profile/types/projects";
 
 export const PROJECTS: Project[] = [
   {
-    id: "sisdocx-merm",
-    title: "SisDocx MERM - Prototype",
-    period: { start: "01.2024", end: "06.2024" },
-    link: "https://github.com/Levting/SisDocx",
-    skills: [
-      "Next.js",
-      "TypeScript",
-      "JWT Authentication",
-      "Djoser",
-      "RTK Query",
-      "Redux Toolkit",
-      "Django",
-      "PostgreSQL",
-    ],
-    description: `Early prototype for SisDocx built in Next.js, before the thesis version needed to align with EEASA's Java/Oracle stack.
-- Entry and authentication model with JWT support via Djoser.
-- State management wired with RTK Query and a lightweight Redux setup.
-- Revisiting the concept with document storage on S3 as a possible future direction.`,
-    logo: "",
-  },
-
-  {
     id: "document-management-system",
     title: "SisDocx - Document Management System",
     period: { start: "06.2024" },
@@ -45,6 +23,27 @@ export const PROJECTS: Project[] = [
 - Centralized management of technical documents across multiple departments.
 - Developed as part of an academic thesis project in collaboration with EEASA.
 - Backend repository: [SisDocx-Backend](https://github.com/Levting/SisDocx-Backend)`,
+    logo: "",
+  },
+  {
+    id: "sisdocx-merm",
+    title: "SisDocx MERM - Prototype",
+    period: { start: "01.2024", end: "06.2024" },
+    link: "https://github.com/Levting/SisDocx",
+    skills: [
+      "Next.js",
+      "TypeScript",
+      "JWT Authentication",
+      "Djoser",
+      "RTK Query",
+      "Redux Toolkit",
+      "Django",
+      "PostgreSQL",
+    ],
+    description: `Early prototype for SisDocx built in Next.js, before the thesis version needed to align with EEASA's Java/Oracle stack.
+- Entry and authentication model with JWT support via Djoser.
+- State management wired with RTK Query and a lightweight Redux setup.
+- Revisiting the concept with document storage on S3 as a possible future direction.`,
     logo: "",
   },
   {

--- a/src/features/profile/data/projects.ts
+++ b/src/features/profile/data/projects.ts
@@ -23,7 +23,6 @@ export const PROJECTS: Project[] = [
 - Centralized management of technical documents across multiple departments.
 - Developed as part of an academic thesis project in collaboration with EEASA.
 - Backend repository: [SisDocx-Backend](https://github.com/Levting/SisDocx-Backend)`,
-    logo: "",
   },
   {
     id: "sisdocx-merm",
@@ -44,7 +43,6 @@ export const PROJECTS: Project[] = [
 - Entry and authentication model with JWT support via Djoser.
 - State management wired with RTK Query and a lightweight Redux setup.
 - Revisiting the concept with document storage on S3 as a possible future direction.`,
-    logo: "",
   },
   {
     id: "color-prediction",
@@ -56,7 +54,6 @@ export const PROJECTS: Project[] = [
 - Computer vision for color classification of garments using image processing techniques.
 - Estimated ~89% accuracy in manual testing across a dataset of over 1200 images.
 - Feature extraction and preprocessing techniques.`,
-    logo: "",
   },
   {
     id: "factx-invoice-system",
@@ -78,7 +75,6 @@ export const PROJECTS: Project[] = [
 - Frontend built with JavaScript and uses Bootstrap to provide an interactive user interface.
 - Allows for easy and fast management of electronic invoices, integrating with SRI services for invoice validation and submission.
 - Backend repository: [Factx-Backend](https://github.com/sebasPalate/Factx-Backend)`,
-    logo: "",
   },
 
   {
@@ -102,6 +98,5 @@ export const PROJECTS: Project[] = [
 - Allows users to make reservations based on availability.
 - CRUD operations for vehicle, staff, and support reservations.
 - Uses Room to manage the local reservation database.`,
-    logo: "",
   },
 ];


### PR DESCRIPTION
Two small fixes after the main CI/Prettier merge:

- **UTA logo**: Added companyLogo to education entry so it shows the university logo
- **Dead code**: Removed logo empty string from all projects - was falsy in JS, DiceBear fallback was always used anyway